### PR TITLE
fix: 优化 getLastSeq 报错

### DIFF
--- a/lib/message/history.js
+++ b/lib/message/history.js
@@ -65,6 +65,8 @@ async function getLastSeq(group_id) {
     });
     const blob = await this.sendOidb("OidbSvc.0x88d_0", body);
     const o = pb.decode(blob)[4][1][3];
+    if (!o)
+        throw ERROR_MSG_NOT_EXISTS;
     return o[22];
 }
 


### PR DESCRIPTION
对于不存在的群聊，getLastSeq 会抛出一个不太直观的错误 `TypeError: Cannot read properties of undefined (reading '22')`
这个 PR 令它和 getGroupMsgs 抛出一样 抛出 `msg not exists` 